### PR TITLE
add: coverage for test case C #3

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Locale;
 
 import org.jabref.logic.importer.fetcher.TrustLevel;
 import org.jabref.logic.util.URLUtil;
@@ -17,6 +18,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.argThat;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.verify;
 
 @FetcherTest
 class FulltextFetchersTest {
@@ -73,5 +77,35 @@ class FulltextFetchersTest {
         FulltextFetchers fetchers = new FulltextFetchers(Set.of(finderLow, finderHigh));
 
         assertEquals(Optional.of(highUrl), fetchers.findFullTextPDF(entry));
+    }
+
+    @Test
+    void findFullTextByDOIDerivedFromTitle() throws Exception {
+        // Entry with only a title,  no DOI, no file
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.TITLE, "'To See or Not to See?' How Do Eye Movements Change Within Immersive Driving Environments");
+
+        //dummy pdf
+        URL expectedPdf = URLUtil.create("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf");
+
+        // Mock fetcher that only returns a PDF if the entry has a DOI
+        // (proving CrossRef actually derived it)
+        FulltextFetcher mockFetcher = mock(FulltextFetcher.class);
+        when(mockFetcher.getTrustLevel()).thenReturn(TrustLevel.SOURCE);
+        when(mockFetcher.findFullText(argThat(e ->
+                e.getField(StandardField.DOI).isPresent()
+        ))).thenReturn(Optional.of(expectedPdf));
+
+        FulltextFetchers fetchers = new FulltextFetchers(Set.of(mockFetcher));
+        Optional<URL> result = fetchers.findFullTextPDF(entry);
+
+        //check if the URL is the same as expected
+        assertEquals(Optional.of(expectedPdf), result);
+
+        // Verify the exact DOI that was derived
+        ArgumentCaptor<BibEntry> captor = ArgumentCaptor.forClass(BibEntry.class);
+        verify(mockFetcher).findFullText(captor.capture());
+        String derivedDoi = captor.getValue().getField(StandardField.DOI).orElse("");
+        assertEquals("10.1145/2667239.2667268", derivedDoi.toLowerCase(Locale.ENGLISH));
     }
 }


### PR DESCRIPTION
- verified test coverage via mutation of line 82 in FulltestFetchers, removed DOI setting, confirming test results.
-
- coverage for test case for full pipeline, where DOI is not given, but is found by searching for the title using fulltextfetchers. The PDF fetching capability is already tested by CrossRef class, and is outside of the scope of fulltextFetchers.java

closes #3 