### PR TITLE
added test coverage for case H

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -909,7 +909,6 @@ class AutoSetFileLinksUtilTest {
 
         Collection<LinkedFile> foundFiles = util.findAssociatedNotLinkedFiles(entry);
 
-
         // Because the PDF on the hard drive is already stored inside the BibEntry's file list, 
         // the utility should filter it out. We expect exactly 0 new files to be discovered
         assertEquals(0, foundFiles.size(), "Should discover exactly zero unlinked files since it is already linked.");

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -911,6 +911,6 @@ class AutoSetFileLinksUtilTest {
 
         // Because the PDF on the hard drive is already stored inside the BibEntry's file list, 
         // the utility should filter it out. We expect exactly 0 new files to be discovered
-        assertEquals(0, foundFiles.size(), "Should discover exactly zero unlinked files since it is already linked.");
+        assertEquals(0, foundFiles.size());
     }
 }


### PR DESCRIPTION
- Created a coverage test for requirement H - `issueH_ignoresAlreadyLinkedFile`.
- This tests to verify the duplicate-checking logic within `AutoSetFileLinksUtil`. It validates that the file-discovery engine correctly filters out files that are already linked to a bibliographic entry. Configuring a BibEntry with a pre-existing LinkedFile and searching an isolated temporary directory, the test ensures the utility returns exactly zero new "candidates". This prevents the system from creating duplicate file attachments.

Closes #8